### PR TITLE
update readme

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,12 @@
 # Readme.md
 
-This repository contains the API documentation for the
-.NET Compiler Platform SDK. The .NET Compiler Platform SDK
-includes APIs that are part of hte [Roslyn SDK](https://github.com/dotnet/roslyn-sdk) and
-[Roslyn](https://github.com/dotnet/roslyn) repositories. The .NET
-Compiler Platform SDK is part of the overall .NET developer documentation.
+This repository contains documentation for the
+[Roslyn platform](https://github.com/dotnet/roslyn) and the
+[.NET Compiler Platform SDK](https://github.com/dotnet/roslyn-sdk). The
+Roslyn platform contains the compiler and is part of every .NET installation.
+The Compiler Platform SDK is available via NuGet and provides tools,
+templates and samples to access to the Roslyn platform. The .NET Compiler
+Platform SDK is part of the overall .NET developer documentation.
 The .NET content team tracks all work for .NET developer documentation
 on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find
 any issues, or have suggestions on how to improve the .NET Compiler platform

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,9 @@
 # Readme.md
 
 This repository contains the API documentation for the
-[.NET Compiler Platform SDK](https://github.com/dotnet/roslyn-sdk). The .NET
+.NET Compiler Platform SDK. The .NET Compiler Platform SDK
+includes APIs that are part of hte [Roslyn SDK](https://github.com/dotnet/roslyn-sdk) and
+[Roslyn](https://github.com/dotnet/roslyn) repositories. The .NET
 Compiler Platform SDK is part of the overall .NET developer documentation.
 The .NET content team tracks all work for .NET developer documentation
 on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find
 any issues, or have suggestions on how to improve the .NET Compiler platform
 SDK documentation, create them on the [docs repository](https://github.com/dotnet/docs/issues).
 That repository contains the source for conceptual documentation, tutorials and more,
-including all the dcoumentation on the .NET Compiler Platform SDK.
+including all the documentation on the .NET Compiler Platform SDK.
 
 This remainder of this file has notes which NuGet packages make up the
 .NET Compiler SDK Meta-package.

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,17 @@
 # Readme.md
 
-This file has notes on building the API reference
-for the Roslyn APIs.
+This repository contains the API documentation for the
+[.NET Compiler Platform SDK](https://github.com/dotnet/roslyn-sdk). The .NET
+Compiler Platform SDK is part of the overall .NET developer documentation.
+The .NET content team tracks all work for .NET developer documentation
+on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find
+any issues, or have suggestions on how to improve the .NET Compiler platform
+SDK documentation, create them on the [docs repository](https://github.com/dotnet/docs/issues).
+That repository contains the source for conceptual documentation, tutorials and more,
+including all the dcoumentation on the .NET Compiler Platform SDK.
+
+This remainder of this file has notes which NuGet packages make up the
+.NET Compiler SDK Meta-package.
 
 ## NuGet Packages that comprise the Roslyn APIs
 

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ SDK documentation, create them on the [docs repository](https://github.com/dotne
 That repository contains the source for conceptual documentation, tutorials and more,
 including all the documentation on the .NET Compiler Platform SDK.
 
-This remainder of this file has notes which NuGet packages make up the
-.NET Compiler SDK Meta-package.
+The remainder of this file has notes which NuGet packages make up the
+.NET Compiler SDK metapackage.
 
 ## NuGet Packages that comprise the Roslyn APIs
 

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@ This repository contains documentation for the
 [Roslyn platform](https://github.com/dotnet/roslyn) and the
 [.NET Compiler Platform SDK](https://github.com/dotnet/roslyn-sdk). The
 Roslyn platform contains the compiler and is part of every .NET installation.
-The Compiler Platform SDK is available via NuGet and provides tools,
-templates and samples to access to the Roslyn platform. The .NET Compiler
+The Compiler Platform SDK provides tools and templates for programmers working
+with the Roslyn platform. The .NET Compiler
 Platform SDK is part of the overall .NET developer documentation.
 The .NET content team tracks all work for .NET developer documentation
 on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find


### PR DESCRIPTION
Redirect issues to the dotnet/docs repo.

While here, add a code of conduct.

See #37 for details on the upcoming plan.

Asking @Mairaw to review. When finalized, this text can be in other repos that are part of dotnet docs.
