### PR TITLE
turn off edit

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -9,9 +9,7 @@
         "roslyn-dotnet"
       ],
       "moniker_ranges": [],
-      "open_to_public_contributors": true,
-      "git_repository_branch_open_to_public_contributors": "master",
-      "git_repository_url_open_to_public_contributors": "https://github.com/dotnet/roslyn-api-docs",
+      "open_to_public_contributors": false,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",


### PR DESCRIPTION
These docs are auto generated from /// comments in the roslyn repository. Therefore, these should not be edited by hand.

See https://github.com/dotnet/roslyn-api-docs/pull/51#issuecomment-404682367