### PR TITLE
Update readme for current practices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,29 +1,16 @@
 # Roslyn API reference documentation
 
-This repository contains documentation for the
-[Roslyn platform](https://github.com/dotnet/roslyn) and the
-[.NET Compiler Platform SDK](https://github.com/dotnet/roslyn-sdk). The
-Roslyn platform contains the compiler and is part of every .NET installation.
-The Compiler Platform SDK provides tools and templates for programmers working
-with the Roslyn platform. The .NET Compiler
-Platform SDK is part of the overall .NET developer documentation.
-The .NET content team tracks all work for .NET developer documentation
-on the [.NET Docs](https://github.com/dotnet/docs) repository. If you find
-any issues, or have suggestions on how to improve the .NET Compiler platform
-SDK documentation, create them on the [docs repository](https://github.com/dotnet/docs/issues).
-That repository contains the source for conceptual documentation, tutorials and more,
-including all the documentation on the .NET Compiler Platform SDK.
+This repository contains the files necessary to publish the roslyn API docs on [Microsoft Learn](https://learn.microsoft.com/dotnet/api/?view=roslyn-dotnet-4.7.0). That includes OPS build configuration and the XML output from the `///` comments on files in the [roslyn](https://github.com/dotnet/roslyn) and [roslyn-sdk](https://github.com/dotnet/roslyn-sdk) repositories. The source of truth for roslyn API documentation is the `///` comments in those repositories. If you find issues with the API documentation, you should report them in those repositories. Issues are disabled in this repo for that reason.
+
+If you wish to make updates by submitting a pull request, it should be done in those repositories. The only updates here should be to the configuration metadata. Other PRs will be closed, and you'll be redirected to the correct source repository.
 
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-The remainder of this file has notes which NuGet packages make up the
-.NET Compiler SDK metapackage.
+The remainder of this file has notes which NuGet packages make up the .NET Compiler SDK metapackage.
 
 ## NuGet Packages that comprise the Roslyn APIs
 
-The package that you need to install to use Roslyn is
-**Microsoft.CodeAnalysis**.  This is a meta-package, so
-there are no DLLs or XML files delivered with it.
+The package that you need to install to use Roslyn is **Microsoft.CodeAnalysis**.  This is a meta-package, so there are no DLLs or XML files delivered with it.
 
 The documentation says that this package contains:
 
@@ -83,4 +70,3 @@ One package has multiple XML files, for .NET standard and .NET Framework:
 - ***Microsoft.CodeAnalysis.Workspaces.Common***
 The `Microsoft.CodeAnalysis.Workspaces.XML` file for .NET Standard and
 `Microsoft.CodeAnalysis.Workspaces.Desktop.XML` and `Microsoft.CodeAnalysis.Workspaces.XML` for .NET 4.6
-


### PR DESCRIPTION
The source of truth for roslyn API docs are the `///` comments in the roslyn and roslyn-sdk repositories.

Explain why issues have been turned off in this repo, and why PRs will most likely be closed without merging.