### PR TITLE
Turn off the feedback system

### DIFF
--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -66,7 +66,7 @@
       "ms.topic": "managed-reference",
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "defaultDevLang": "csharp",
-      "feedback_system": "GitHub",
+      "feedback_system": "None",
       "feedback_github_repo": "dotnet/roslyn",
       "feedback_product_url": "https://developercommunity.visualstudio.com/spaces/61/index.html"
     },


### PR DESCRIPTION
Issues with the rolsyn API docs should be routed to the dotnet/roslyn repo as the source of truth is the `///` comments in the source.