### PR TITLE
Update topic type

### DIFF
--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -62,7 +62,7 @@
       "ms.author": "dotnetcontent",
       "searchScope": [".NET"],
       "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/7696cda6-0510-47f6-8302-71bb5d2e28cf"],
-      "ms.topic": "managed-reference",
+      "ms.topic": "generated-reference",
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "defaultDevLang": "csharp",
       "feedback_system": "OpenSource",


### PR DESCRIPTION
All the roslyn API docs are generated from `///` comments, so update this to match.